### PR TITLE
Add experience section with navigation link and styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,6 +125,10 @@
                     <i class="fas fa-user"></i>
                     <span>About</span>
                 </a>
+                <a href="#experience" class="nav-link" data-page="experience">
+                    <i class="fas fa-briefcase"></i>
+                    <span>Experience</span>
+                </a>
                 <a href="#projects" class="nav-link" data-page="projects">
                     <i class="fas fa-code"></i>
                     <span>Projects</span>
@@ -289,6 +293,21 @@
                             </div>
                         </div>
                     </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Experience Section -->
+        <section id="experience" class="page-section">
+            <div class="container">
+                <div class="section-header">
+                    <h2 class="section-title">Experience</h2>
+                    <p class="section-subtitle">Professional background</p>
+                </div>
+                <div class="experience-item">
+                    <h3>Cybersecurity Analyst</h3>
+                    <p class="experience-company">Apolo Cybersecurity</p>
+                    <p class="experience-description">Focused on SOC operations, threat hunting and cloud security.</p>
                 </div>
             </div>
         </section>

--- a/styles/main.css
+++ b/styles/main.css
@@ -946,6 +946,21 @@ a:hover {
     font-weight: 600;
 }
 
+/* ===== EXPERIENCE SECTION ===== */
+#experience {
+    padding: 4rem 0;
+    background: var(--bg-secondary);
+}
+
+.experience-item {
+    margin-bottom: 2rem;
+    padding: 1.5rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 1rem;
+    box-shadow: var(--shadow-md);
+}
+
 /* ===== PROJECTS SECTION ===== */
 .projects-grid {
     display: flex;


### PR DESCRIPTION
## Summary
- add navigation entry for new Experience section
- implement Experience section content in homepage
- style Experience section

## Testing
- `python -m http.server 8000` and `curl -s http://localhost:8000/index.html | rg "experience" -n`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a722458d9c8326aacd7cf11b8079a8